### PR TITLE
fix(process): gracefully exit process

### DIFF
--- a/lib/hexo.js
+++ b/lib/hexo.js
@@ -10,6 +10,8 @@ var goodbye = require('./goodbye');
 var minimist = require('minimist');
 var camelCaseKeys = require('hexo-util/lib/camel_case_keys');
 
+class HexoNotFoundError extends Error {}
+
 function entry(cwd, args) {
   cwd = cwd || process.cwd();
   args = camelCaseKeys(args || minimist(process.argv.slice(2)));
@@ -21,11 +23,11 @@ function entry(cwd, args) {
   process.title = 'hexo';
 
   function handleError(err) {
-    if (err) {
+    if (err && !(err instanceof HexoNotFoundError)) {
       log.fatal(err);
     }
 
-    process.exit(2);
+    process.exitCode = 2;
   }
 
   return findPkg(cwd, args).then(function(path) {
@@ -36,7 +38,7 @@ function entry(cwd, args) {
     return loadModule(path, args).catch(function() {
       log.error('Local hexo not found in %s', chalk.magenta(tildify(path)));
       log.error('Try running: \'npm install hexo --save\'');
-      process.exit(2);
+      throw new HexoNotFoundError;
     });
   }).then(function(mod) {
     if (mod) hexo = mod;


### PR DESCRIPTION
As is noted on https://nodejs.org/api/process.html#process_process_exit_code

> In most situations, it is not actually necessary to call process.exit() explicitly.

It is problematic to print stdout and instruct process.exit() call. Now we set process.exitCode to allow the process exit naturally