### PR TITLE
Support Yarn Workspaces

### DIFF
--- a/lib/hexo.js
+++ b/lib/hexo.js
@@ -7,7 +7,6 @@ var Context = require('./context');
 var findPkg = require('./find_pkg');
 var goodbye = require('./goodbye');
 var minimist = require('minimist');
-var resolve = require('resolve');
 var camelCaseKeys = require('hexo-util/lib/camel_case_keys');
 
 class HexoNotFoundError extends Error {}
@@ -86,7 +85,7 @@ entry.version = require('../package.json').version;
 
 function loadModule(path, args) {
   return Promise.try(function() {
-    var modulePath = resolve.sync('hexo', { basedir: path });
+    var modulePath = require.resolve('hexo', { paths: [path] });
     var Hexo = require(modulePath);
 
     return new Hexo(path, args);

--- a/lib/hexo.js
+++ b/lib/hexo.js
@@ -2,12 +2,12 @@
 
 var chalk = require('chalk');
 var tildify = require('tildify');
-var pathFn = require('path');
 var Promise = require('bluebird');
 var Context = require('./context');
 var findPkg = require('./find_pkg');
 var goodbye = require('./goodbye');
 var minimist = require('minimist');
+var resolve = require('resolve')
 var camelCaseKeys = require('hexo-util/lib/camel_case_keys');
 
 class HexoNotFoundError extends Error {}
@@ -86,7 +86,7 @@ entry.version = require('../package.json').version;
 
 function loadModule(path, args) {
   return Promise.try(function() {
-    var modulePath = pathFn.join(path, 'node_modules', 'hexo');
+    var modulePath = resolve.sync('hexo', { basedir: path });
     var Hexo = require(modulePath);
 
     return new Hexo(path, args);

--- a/lib/hexo.js
+++ b/lib/hexo.js
@@ -7,6 +7,7 @@ var Context = require('./context');
 var findPkg = require('./find_pkg');
 var goodbye = require('./goodbye');
 var minimist = require('minimist');
+var resolve = require('resolve');
 var camelCaseKeys = require('hexo-util/lib/camel_case_keys');
 
 class HexoNotFoundError extends Error {}
@@ -85,7 +86,7 @@ entry.version = require('../package.json').version;
 
 function loadModule(path, args) {
   return Promise.try(function() {
-    var modulePath = require.resolve('hexo', { paths: [path] });
+    var modulePath = resolve.sync('hexo', { basedir: path });
     var Hexo = require(modulePath);
 
     return new Hexo(path, args);

--- a/lib/hexo.js
+++ b/lib/hexo.js
@@ -7,7 +7,7 @@ var Context = require('./context');
 var findPkg = require('./find_pkg');
 var goodbye = require('./goodbye');
 var minimist = require('minimist');
-var resolve = require('resolve')
+var resolve = require('resolve');
 var camelCaseKeys = require('hexo-util/lib/camel_case_keys');
 
 class HexoNotFoundError extends Error {}

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "hexo-util": "^0.6.0",
     "minimist": "^1.2.0",
     "object-assign": "^4.1.0",
+    "resolve": "^1.5.0",
     "tildify": "^1.2.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "hexo-util": "^0.6.0",
     "minimist": "^1.2.0",
     "object-assign": "^4.1.0",
-    "resolve": "^1.5.0",
     "tildify": "^1.2.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -35,13 +35,14 @@
     "abbrev": "^1.0.7",
     "bluebird": "^3.4.0",
     "chalk": "^1.1.3",
+    "command-exists": "^1.2.0",
     "hexo-fs": "^0.2.0",
     "hexo-log": "^0.2.0",
     "hexo-util": "^0.6.0",
     "minimist": "^1.2.0",
     "object-assign": "^4.1.0",
-    "tildify": "^1.2.0",
-    "command-exists": "^1.2.0"
+    "resolve": "^1.5.0",
+    "tildify": "^1.2.0"
   },
   "devDependencies": {
     "chai": "^3.5.0",


### PR DESCRIPTION
If docs are included as a part of the primary application via yarn workspaces (See https://yarnpkg.com/lang/en/docs/workspaces/) the module resolution for the main `hexo` package fails, because it is nested above.

This PR addresses this issue by replacing the current custom module resolution with the [resolve](https://www.npmjs.com/package/resolve) which implements the resolve algorithm.

This, in my opinion, fits the design requirements as well as extending it to allow for the yarn workspace issue without much hassle.