### PR TITLE
Set support version of node.js explicitly as 6, 8, 9.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ cache:
 
 node_js:
   - "6"
+  - "8"
   - "node"
 
 script:

--- a/package.json
+++ b/package.json
@@ -57,5 +57,8 @@
     "proxyquire": "^1.7.9",
     "rewire": "^2.5.1",
     "sinon": "^1.17.4"
+  },
+  "engines": {
+    "node": ">=6.9.0"
   }
 }


### PR DESCRIPTION
In the current setting of travis-ci, test target is v6 and stable.

Therefore, it can not be said that it actually supports the previous version.
So, you should explicitly write support version in package.json.

When this PR is applied, I plan to do semiautomatic refactoring using lebab, PR to upgrade each package, and so on.