### PR TITLE
Update devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,16 +43,16 @@
     "tildify": "^1.2.0"
   },
   "devDependencies": {
-    "chai": "^3.5.0",
-    "chai-as-promised": "^5.3.0",
-    "eslint": "^4.19.1",
+    "chai": "^4.1.2",
+    "chai-as-promised": "^7.1.1",
+    "eslint": "^5.6.0",
     "eslint-config-hexo": "^3.0.0",
-    "hexo-renderer-marked": "^0.2.10",
-    "istanbul": "^0.4.3",
-    "mocha": "^2.5.3",
-    "proxyquire": "^1.7.9",
-    "rewire": "^2.5.1",
-    "sinon": "^1.17.4"
+    "hexo-renderer-marked": "^0.3.2",
+    "istanbul": "^0.4.5",
+    "mocha": "^5.2.0",
+    "proxyquire": "^2.1.0",
+    "rewire": "^4.0.1",
+    "sinon": "^6.3.4"
   },
   "engines": {
     "node": ">=6.9.0"

--- a/test/scripts/context.js
+++ b/test/scripts/context.js
@@ -21,7 +21,7 @@ describe('context', function() {
         result.should.eql(args);
         spy.calledOnce.should.be.true;
         spy.lastCall.args[0].should.eql(args);
-        spy.reset();
+        spy.resetHistory();
       });
     });
 
@@ -42,7 +42,7 @@ describe('context', function() {
         result.should.eql(args);
         spy.calledOnce.should.be.true;
         spy.lastCall.args[0].should.eql(args);
-        spy.reset();
+        spy.resetHistory();
         done();
       });
     });
@@ -52,7 +52,7 @@ describe('context', function() {
         if (err) return done(err);
 
         spy.calledOnce.should.be.true;
-        spy.reset();
+        spy.resetHistory();
         done();
       });
     });

--- a/test/scripts/help.js
+++ b/test/scripts/help.js
@@ -142,7 +142,7 @@ describe('help', function() {
   });
 
   it('show version info', function() {
-    sinon.stub(hexo, 'call', function() {
+    sinon.stub(hexo, 'call').callsFake(() => {
       return Promise.resolve();
     });
 


### PR DESCRIPTION
Update devDependencies and fix some tests

* [sinon.stub(object, method, func) is removed](https://sinonjs.org/guides/migrating-to-3.0). Use `callsFake` instead of it.
* [spy.reset is removed](https://sinonjs.org/guides/migrating-to-5.0). Use `resetHistory` instead of it.