### PR TITLE
Update sinon to 6.3.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "mocha": "^2.5.3",
     "proxyquire": "^1.7.9",
     "rewire": "^2.5.1",
-    "sinon": "^1.17.4"
+    "sinon": "^6.3.5"
   },
   "engines": {
     "node": ">=6.9.0"

--- a/test/scripts/context.js
+++ b/test/scripts/context.js
@@ -21,7 +21,7 @@ describe('context', function() {
         result.should.eql(args);
         spy.calledOnce.should.be.true;
         spy.lastCall.args[0].should.eql(args);
-        spy.reset();
+        spy.resetHistory();
       });
     });
 
@@ -42,7 +42,7 @@ describe('context', function() {
         result.should.eql(args);
         spy.calledOnce.should.be.true;
         spy.lastCall.args[0].should.eql(args);
-        spy.reset();
+        spy.resetHistory();
         done();
       });
     });
@@ -52,7 +52,7 @@ describe('context', function() {
         if (err) return done(err);
 
         spy.calledOnce.should.be.true;
-        spy.reset();
+        spy.resetHistory();
         done();
       });
     });

--- a/test/scripts/help.js
+++ b/test/scripts/help.js
@@ -142,7 +142,7 @@ describe('help', function() {
   });
 
   it('show version info', function() {
-    sinon.stub(hexo, 'call', function() {
+    sinon.stub(hexo, 'call').callsFake(() => {
       return Promise.resolve();
     });
 


### PR DESCRIPTION
From (#32) PR.

Update sinon 6.3.5
The sinon has breaking change. So, this PR fix test case.

* [sinon.stub(object, method, func) is removed](https://sinonjs.org/guides/migrating-to-3.0). Use `callsFake` instead of it.
* [spy.reset is removed](https://sinonjs.org/guides/migrating-to-5.0). Use `resetHistory` instead of it.