### PR TITLE
Fixed the invalid type error while running init with a numeric folder name

### DIFF
--- a/lib/console/init.js
+++ b/lib/console/init.js
@@ -18,7 +18,7 @@ function initConsole(args) {
   }, args);
 
   var baseDir = this.base_dir;
-  var target = args._[0] ? pathFn.resolve(baseDir, args._[0]) : baseDir;
+  var target = args._[0] ? pathFn.resolve(baseDir, String(args._[0])) : baseDir;
   var log = this.log;
   var promise, npmCommand;
 


### PR DESCRIPTION
This PR fixes an invalid type error that occurs while running `hexo init` with a numeric folder name.

E.g. Executing `hexo init 233` will produce the error as follows:
```
FATAL Something's wrong. Maybe you can find the solution here: http://hexo.io/docs/troubleshooting.html
TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received type number
    at assertPath (path.js:39:11)
    at Object.resolve (path.js:1088:7)
    ... (Omitted)
```
Since there'll be a need to create a new hexo project with numeric folder name in some cases, I've ensured that a string will be passed to the `resolve()` function.