### PR TITLE
docs(readme): add npmjs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # hexo-cli
 
-[![Build Status](https://travis-ci.org/hexojs/hexo-cli.svg?branch=master)](https://travis-ci.org/hexojs/hexo-cli)  [![NPM version](https://badge.fury.io/js/hexo-cli.svg)](http://badge.fury.io/js/hexo-cli) [![Coverage Status](https://coveralls.io/repos/hexojs/hexo-cli/badge.svg?branch=master)](https://coveralls.io/r/hexojs/hexo-cli?branch=master) [![Build status](https://ci.appveyor.com/api/projects/status/aa44wp75752x1t47/branch/master?svg=true)](https://ci.appveyor.com/project/tommy351/hexo-cli/branch/master)
+[![Build Status](https://travis-ci.org/hexojs/hexo-cli.svg?branch=master)](https://travis-ci.org/hexojs/hexo-cli)
+[![NPM version](https://badge.fury.io/js/hexo-cli.svg)](https://www.npmjs.com/package/hexo-cli)
+[![Coverage Status](https://coveralls.io/repos/hexojs/hexo-cli/badge.svg?branch=master)](https://coveralls.io/r/hexojs/hexo-cli?branch=master)
+[![Build status](https://ci.appveyor.com/api/projects/status/aa44wp75752x1t47/branch/master?svg=true)](https://ci.appveyor.com/project/tommy351/hexo-cli/branch/master)
 
 Command line interface for Hexo.
 


### PR DESCRIPTION
also separate each badge by new line, but they will still be displayed side-by-side.