### PR TITLE
fix(init): shallow clone and reduce verbosity

### DIFF
--- a/lib/console/init.js
+++ b/lib/console/init.js
@@ -54,12 +54,11 @@ function initConsole(args) {
         cwd: target,
         stdio: 'inherit'
       });
-    } else {
-      return spawn(npmCommand, ['install', '--only=production', '--optional=false', '--silent'], {
-        cwd: target,
-        stdio: 'inherit'
-      });
     }
+    return spawn(npmCommand, ['install', '--only=production', '--optional=false', '--silent'], {
+      cwd: target,
+      stdio: 'inherit'
+    });
   }).then(() => {
     log.info('Start blogging with Hexo!');
   }).catch(() => {

--- a/lib/console/init.js
+++ b/lib/console/init.js
@@ -28,7 +28,7 @@ function initConsole(args) {
   let promise;
 
   if (args.clone) {
-    promise = spawn('git', ['clone', '--recursive', GIT_REPO_URL, target], {
+    promise = spawn('git', ['clone', '--recurse-submodules', '--depth=1', '--quiet', GIT_REPO_URL, target], {
       stdio: 'inherit'
     });
   } else {
@@ -49,10 +49,17 @@ function initConsole(args) {
 
     const npmCommand = commandExistsSync('yarn') ? 'yarn' : 'npm';
 
-    return spawn(npmCommand, ['install', '--production'], {
-      cwd: target,
-      stdio: 'inherit'
-    });
+    if (npmCommand === 'yarn') {
+      return spawn(npmCommand, ['install', '--production', '--ignore-optional', '--silent'], {
+        cwd: target,
+        stdio: 'inherit'
+      });
+    } else {
+      return spawn(npmCommand, ['install', '--only=production', '--optional=false', '--silent'], {
+        cwd: target,
+        stdio: 'inherit'
+      });
+    }
   }).then(() => {
     log.info('Start blogging with Hexo!');
   }).catch(() => {


### PR DESCRIPTION
- git:
  - `--recursive` has been deprecated in git [2.13](https://www.git-scm.com/docs/git-clone/2.13.2), `--recurse-submodules` is available in git [2.3](https://www.git-scm.com/docs/git-clone/2.3.0) (possibly available in older version).
  - `--depth=1` for shallow clone the hexo-starter, resulting in faster and smaller clone.

- yarn and npm:
  - ignore optional dependencies

- Reduce verbosity for all commands.

from

```
$ hexo init
INFO  Cloning hexo-starter https://github.com/hexojs/hexo-starter.git
Cloning into 'test'...
remote: Enumerating objects: 14, done.
remote: Counting objects: 100% (14/14), done.
remote: Compressing objects: 100% (9/9), done.
remote: Total 14 (delta 0), reused 11 (delta 0), pack-reused 0
Unpacking objects: 100% (14/14), done.
Submodule 'themes/landscape' (https://github.com/hexojs/hexo-theme-landscape.git) registered for path 'themes/landscape'
Cloning into 'test/themes/landscape'...
remote: Enumerating objects: 32, done.        
remote: Counting objects: 100% (32/32), done.        
remote: Compressing objects: 100% (25/25), done.        
Receiving objects: 100% (1054/1054), 3.21 MiB | 425.00 KiB/s, done.
remote: Total 1054 (delta 20), reused 10 (delta 7), pack-reused 1022        
Resolving deltas: 100% (578/578), done.
Submodule path 'themes/landscape': checked out '73a23c51f8487cfcd7c6deec96ccc7543960d350'
INFO  Install dependencies
INFO  Start blogging with Hexo!
```

to

```
$ hexo init
INFO  Cloning hexo-starter https://github.com/hexojs/hexo-starter.git
INFO  Install dependencies
INFO  Start blogging with Hexo!
```

Ref: [git](https://www.git-scm.com/docs/git-clone/), [yarn](https://yarnpkg.com/lang/en/docs/cli/install/), [npm](https://docs.npmjs.com/misc/config).