### PR TITLE
refactor: destructure hexo-util

### DIFF
--- a/lib/console/init.js
+++ b/lib/console/init.js
@@ -5,7 +5,7 @@ const pathFn = require('path');
 const chalk = require('chalk');
 const fs = require('hexo-fs');
 const tildify = require('tildify');
-const spawn = require('hexo-util/lib/spawn');
+const { spawn } = require('hexo-util');
 const commandExistsSync = require('command-exists').sync;
 
 const ASSET_DIR = pathFn.join(__dirname, '../../assets');

--- a/lib/hexo.js
+++ b/lib/hexo.js
@@ -8,7 +8,7 @@ const findPkg = require('./find_pkg');
 const goodbye = require('./goodbye');
 const minimist = require('minimist');
 const resolve = require('resolve');
-const camelCaseKeys = require('hexo-util/lib/camel_case_keys');
+const { camelCaseKeys } = require('hexo-util');
 
 class HexoNotFoundError extends Error {}
 

--- a/test/scripts/init.js
+++ b/test/scripts/init.js
@@ -4,7 +4,7 @@ require('chai').should();
 const pathFn = require('path');
 const fs = require('hexo-fs');
 const Promise = require('bluebird');
-const util = require('hexo-util');
+const { hash } = require('hexo-util');
 const rewire = require('rewire');
 const Context = require('../../lib/context');
 const assetDir = pathFn.join(__dirname, '../../assets');
@@ -32,8 +32,8 @@ describe('init', () => {
   }
 
   function compareFile(a, b) {
-    const streamA = new util.HashStream();
-    const streamB = new util.HashStream();
+    const streamA = hash.createSha1Hash();
+    const streamB = hash.createSha1Hash();
 
     return Promise.all([
       pipeStream(fs.createReadStream(a), streamA),

--- a/test/scripts/init.js
+++ b/test/scripts/init.js
@@ -4,7 +4,7 @@ require('chai').should();
 const pathFn = require('path');
 const fs = require('hexo-fs');
 const Promise = require('bluebird');
-const { hash } = require('hexo-util');
+const { createSha1Hash } = require('hexo-util');
 const rewire = require('rewire');
 const Context = require('../../lib/context');
 const assetDir = pathFn.join(__dirname, '../../assets');
@@ -32,8 +32,8 @@ describe('init', () => {
   }
 
   function compareFile(a, b) {
-    const streamA = hash.createSha1Hash();
-    const streamB = hash.createSha1Hash();
+    const streamA = createSha1Hash();
+    const streamB = createSha1Hash();
 
     return Promise.all([
       pipeStream(fs.createReadStream(a), streamA),


### PR DESCRIPTION
[`HashStream()`](https://github.com/hexojs/hexo-util#hashstream) has been deprecated in favor of [`createSha1Hash()`](https://github.com/hexojs/hexo-util#createsha1hash)