### PR TITLE
test(mocha): use yml format

### DIFF
--- a/.mocharc.yml
+++ b/.mocharc.yml
@@ -1,0 +1,2 @@
+color: true
+reporter: spec

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,1 +1,0 @@
---reporter spec


### PR DESCRIPTION
`mocha.opts` has been deprecated in [mocha v7](https://mochajs.org/#-opts-path).