### PR TITLE
ci(appveyor): stop updating npm

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,6 @@ matrix:
 # Install scripts. (runs after repo cloning)
 install:
   - ps: Install-Product node $env:nodejs_version
-  - npm install -g npm
   - npm install
 
 cache:


### PR DESCRIPTION
buggy in Node 14 and unnecessary.