### PR TITLE
chore(deps): remove acorn

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -445,7 +445,8 @@
     "acorn": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.2.0.tgz",
-      "integrity": "sha512-apwXVmYVpQ34m/i71vrApRrRKCWQnZZF1+npOD0WV5xZFfwWOmKGQ2RWlfdy9vWITsenisM8M0Qeq8agcFHNiQ=="
+      "integrity": "sha512-apwXVmYVpQ34m/i71vrApRrRKCWQnZZF1+npOD0WV5xZFfwWOmKGQ2RWlfdy9vWITsenisM8M0Qeq8agcFHNiQ==",
+      "dev": true
     },
     "acorn-jsx": {
       "version": "5.2.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
   "license": "MIT",
   "dependencies": {
     "abbrev": "^1.1.1",
-    "acorn": "^7.1.1",
     "bluebird": "^3.5.5",
     "chalk": "^4.0.0",
     "command-exists": "^1.2.8",


### PR DESCRIPTION
`acorn` is introduced in #50. However, I don't see why the `acorn` is required.

Seeing the related issue, still don't know why acorn should be included in dependencies.

The PR shouldn't be merged before @tomap gives the explanation, in case the PR breaks something.