### PR TITLE
refactor(init): drop yarn support

### DIFF
--- a/lib/console/init.js
+++ b/lib/console/init.js
@@ -6,7 +6,6 @@ const chalk = require('chalk');
 const { existsSync, readdirSync, rmdir, unlink, copyDir, readdir, stat } = require('hexo-fs');
 const tildify = require('tildify');
 const { spawn } = require('hexo-util');
-const commandExistsSync = require('command-exists').sync;
 
 const ASSET_DIR = join(__dirname, '../../assets');
 const GIT_REPO_URL = 'https://github.com/hexojs/hexo-starter.git';
@@ -47,15 +46,7 @@ function initConsole(args) {
 
     log.info('Install dependencies');
 
-    const npmCommand = commandExistsSync('yarn') ? 'yarn' : 'npm';
-
-    if (npmCommand === 'yarn') {
-      return spawn(npmCommand, ['install', '--production', '--ignore-optional', '--silent'], {
-        cwd: target,
-        stdio: 'inherit'
-      });
-    }
-    return spawn(npmCommand, ['install', '--only=production', '--optional=false', '--silent'], {
+    return spawn('npm', ['install', '--only=production', '--optional=false', '--silent'], {
       cwd: target,
       stdio: 'inherit'
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -822,11 +822,6 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
-    "command-exists": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
-      "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w=="
-    },
     "commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "abbrev": "^1.1.1",
     "bluebird": "^3.5.5",
     "chalk": "^4.0.0",
-    "command-exists": "^1.2.8",
     "hexo-fs": "^3.0.1",
     "hexo-log": "^1.0.0",
     "hexo-util": "^2.0.0",


### PR DESCRIPTION
Drop Yarn support.

`Yarn@2` has too many breaking changes that are not compatible with Hexo:

- `Yarn@2` has no `node_modules` by default
- `Yarn@2` has no `--production` parameter any more (which breaks `hexo init`)
- `Yarn@2` makes package resolving much more difficult

At least we shouldn't use Yarn in `hexo init`.