### PR TITLE
fix(init): show where to run npm

### DIFF
--- a/lib/console/init.js
+++ b/lib/console/init.js
@@ -62,7 +62,7 @@ function initConsole(args) {
   }).then(() => {
     log.info('Start blogging with Hexo!');
   }).catch(() => {
-    log.warn('Failed to install dependencies. Please run \'npm install\' manually!');
+    log.warn(`Failed to install dependencies. Please run 'npm install' in "${target}" folder.`);
   });
 }
 


### PR DESCRIPTION
this is helpful when running `$ hexo init custom-folder`.