### PR TITLE
release: 4.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hexo-cli",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexo-cli",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "description": "Command line interface for Hexo",
   "main": "lib/hexo",
   "bin": {


### PR DESCRIPTION
https://github.com/hexojs/hexo-cli/pull/227

Other PRs only change package-lock which is not published.