### PR TITLE
feat(version): show distro version

### DIFF
--- a/lib/console/version.js
+++ b/lib/console/version.js
@@ -3,9 +3,10 @@
 const os = require('os');
 const pkg = require('../../package.json');
 const Promise = require('bluebird');
+const { spawn } = require('hexo-util');
 
-function versionConsole(args) {
-  const versions = process.versions;
+async function versionConsole(args) {
+  const { versions, platform } = process;
   const keys = Object.keys(versions);
 
   if (this.version) {
@@ -13,14 +14,26 @@ function versionConsole(args) {
   }
 
   console.log('hexo-cli:', pkg.version);
-  console.log('os:', os.type(), os.release(), os.platform(), os.arch());
+
+  let osInfo = '';
+  if (platform === 'darwin') osInfo = await spawn('sw_vers', '-productVersion');
+  else if (platform === 'linux') {
+    const v = await spawn('cat', '/etc/os-release');
+    const distro = (v || '').match(/NAME="(.+)"/);
+    const versionInfo = (v || '').match(/VERSION="(.+)"/) || ['', ''];
+    const versionStr = versionInfo !== null ? versionInfo[1] : '';
+    osInfo = `${distro[1]} ${versionStr}`.trim() || '';
+  }
+
+  osInfo = `${os.platform()} ${os.release()} ${osInfo}`;
+  console.log('os:', osInfo);
 
   for (let i = 0, len = keys.length; i < len; i++) {
     const key = keys[i];
     console.log('%s: %s', key, versions[key]);
   }
 
-  return Promise.resolve();
+  await Promise.resolve();
 }
 
 module.exports = versionConsole;

--- a/test/scripts/version.js
+++ b/test/scripts/version.js
@@ -3,10 +3,11 @@
 require('chai').should();
 const Context = require('../../lib/context');
 const sinon = require('sinon');
-const { arch, platform, release, type } = require('os');
+const { platform, release } = require('os');
 const { format } = require('util');
 const cliVersion = require('../../package.json').version;
 const rewire = require('rewire');
+const { spawn } = require('hexo-util')
 
 function getConsoleLog({ args }) {
   return args.map(arr => format.apply(null, arr)).join('\n');
@@ -26,16 +27,26 @@ describe('version', () => {
     })(async () => {
       await versionModule.call(hexo, {_: []});
       const output = getConsoleLog(spy);
-      const expected = [
-        `hexo-cli: ${cliVersion}`,
-        `os: ${type()} ${release()} ${platform()} ${arch()}`
-      ];
+      const expected = [];
 
       Object.keys(process.versions).forEach(key => {
         expected.push(`${key}: ${process.versions[key]}`);
       });
 
-      output.should.eql(expected.join('\n'));
+      output.should.contain(`hexo-cli: ${cliVersion}`);
+      output.should.contain(`os: ${platform()} ${release()}`);
+      output.should.contain(expected.join('\n'));
+
+      if (process.env.CI === 'true') {
+        if (process.platform === 'darwin') {
+          const osInfo = await spawn('sw_vers', '-productVersion')
+          output.should.contain(`os: ${platform()} ${release()} ${osInfo}`);
+        } else if (process.platform === 'linux') {
+          const v = await spawn('cat', '/etc/os-release');
+          const distro = (v || '').match(/NAME="(.+)"/);
+          output.should.contain(`os: ${platform()} ${release()} ${distro[1]}`);
+        }
+      }
     });
   });
 


### PR DESCRIPTION
https://github.com/tabrindle/envinfo/blob/1ef184ff1850a20863b877d7485e51bd8f215f2f/src/helpers/system.js#L41-L49

[`os.type()`](https://nodejs.org/api/os.html#os_os_type) and [`os.arch()`](https://nodejs.org/api/os.html#os_os_arch) are removed as they are not useful info.