### PR TITLE
Throw an err when we don't have hexo in package.json

### DIFF
--- a/lib/find_pkg.js
+++ b/lib/find_pkg.js
@@ -16,7 +16,12 @@ function checkPkg(path) {
 
   return readFile(pkgPath).then(content => {
     const json = JSON.parse(content);
-    if (typeof json.hexo === 'object') return path;
+    if (typeof json.hexo === 'object') {
+      return path
+    }
+    else {
+      throw "Can't find hexo in " + pkgPath;
+    };
   }).catch(err => {
     if (err && err.code === 'ENOENT') {
       const parent = dirname(path);


### PR DESCRIPTION
As https://github.com/hexojs/hexo-cli/issues/249 mentioned, this commit hopes to add a prompt to facilitate the user to quickly identify the root cause of the problem

Before:
![image](https://user-images.githubusercontent.com/7285119/95008652-4c2a7a00-064e-11eb-8de4-3719e87496d0.png)

After:
![image](https://user-images.githubusercontent.com/7285119/95008689-9ca1d780-064e-11eb-818c-0a78e2900155.png)
