### PR TITLE
refactor & style: let command default to be 'help'

### DIFF
--- a/lib/hexo.js
+++ b/lib/hexo.js
@@ -48,19 +48,11 @@ function entry(cwd = process.cwd(), args) {
 
     return hexo.init();
   }).then(() => {
-    let cmd = '';
+    let cmd = 'help';
 
     if (!args.h && !args.help) {
-      cmd = args._.shift();
-
-      if (cmd) {
-        const c = hexo.extend.console.get(cmd);
-        if (!c) cmd = 'help';
-      } else {
-        cmd = 'help';
-      }
-    } else {
-      cmd = 'help';
+      const c = args._.shift();
+      if (c && hexo.extend.console.get(c)) cmd = c;
     }
 
     watchSignal(hexo);

--- a/test/scripts/version.js
+++ b/test/scripts/version.js
@@ -7,7 +7,7 @@ const { platform, release } = require('os');
 const { format } = require('util');
 const cliVersion = require('../../package.json').version;
 const rewire = require('rewire');
-const { spawn } = require('hexo-util')
+const { spawn } = require('hexo-util');
 
 function getConsoleLog({ args }) {
   return args.map(arr => format.apply(null, arr)).join('\n');
@@ -39,7 +39,7 @@ describe('version', () => {
 
       if (process.env.CI === 'true') {
         if (process.platform === 'darwin') {
-          const osInfo = await spawn('sw_vers', '-productVersion')
+          const osInfo = await spawn('sw_vers', '-productVersion');
           output.should.contain(`os: ${platform()} ${release()} ${osInfo}`);
         } else if (process.platform === 'linux') {
           const v = await spawn('cat', '/etc/os-release');


### PR DESCRIPTION
Because cmd will be 'help' if do not specify the command. I think the modification enhances readability.

BTW, I added semicolon,which will be blocked by ESlint if missing.