### PR TITLE
Improve error logging

### DIFF
--- a/lib/hexo.js
+++ b/lib/hexo.js
@@ -23,7 +23,7 @@ function entry(cwd = process.cwd(), args) {
 
   function handleError(err) {
     if (err && !(err instanceof HexoNotFoundError)) {
-      log.fatal(err);
+      log.fatal(`err: ${err}`);
     }
 
     process.exitCode = 2;


### PR DESCRIPTION
I don't know why. But the previous code log `FATAL` only while with this change it can log the stacktrace.

cc @stevenjoezhang 