### PR TITLE
refactor: migrate typescript

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,3 +2,4 @@ node_modules/
 coverage/
 tmp/
 assets/
+dist/

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,4 +1,8 @@
 {
-  "extends": "hexo",
-  "root": true
+  "root": true,
+  "extends": "hexo/ts.js",
+  "parserOptions": {
+    "sourceType": "module",
+    "ecmaVersion": 2020
+  }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,5 +4,8 @@
   "parserOptions": {
     "sourceType": "module",
     "ecmaVersion": 2020
+  },
+  "rules": {
+    "@typescript-eslint/no-var-requires": 0
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ tmp/
 .idea/
 .nyc_output/
 .vscode/
+dist/

--- a/lib/console/help.ts
+++ b/lib/console/help.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 import {underline, bold} from 'picocolors';
 import {readFile} from 'hexo-fs';
 import {join} from 'path';

--- a/lib/console/help.ts
+++ b/lib/console/help.ts
@@ -1,6 +1,6 @@
-import {underline, bold} from 'picocolors';
-import {readFile} from 'hexo-fs';
-import {join} from 'path';
+import { underline, bold } from 'picocolors';
+import { readFile } from 'hexo-fs';
+import { join } from 'path';
 import Promise from 'bluebird';
 
 const COMPLETION_DIR = join(__dirname, '../../completion');

--- a/lib/console/help.ts
+++ b/lib/console/help.ts
@@ -1,9 +1,9 @@
 'use strict';
 
-const { underline, bold } = require('picocolors');
-const { readFile } = require('hexo-fs');
-const { join } = require('path');
-const Promise = require('bluebird');
+import {underline, bold} from 'picocolors';
+import {readFile} from 'hexo-fs';
+import {join} from 'path';
+import Promise from 'bluebird';
 
 const COMPLETION_DIR = join(__dirname, '../../completion');
 
@@ -115,4 +115,4 @@ function printCompletion(type) {
   });
 }
 
-module.exports = helpConsole;
+export = helpConsole;

--- a/lib/console/index.ts
+++ b/lib/console/index.ts
@@ -1,9 +1,13 @@
 'use strict';
 
-module.exports = function(ctx) {
+import helpConsole from './help';
+import initConsole from './init';
+import versionConsole from './version';
+
+export = function(ctx) {
   const { console } = ctx.extend;
 
-  console.register('help', 'Get help on a command.', {}, require('./help'));
+  console.register('help', 'Get help on a command.', {}, helpConsole);
 
   console.register('init', 'Create a new Hexo folder.', {
     desc: 'Create a new Hexo folder at the specified path or the current directory.',
@@ -15,7 +19,7 @@ module.exports = function(ctx) {
       {name: '--no-clone', desc: 'Copy files instead of cloning from GitHub'},
       {name: '--no-install', desc: 'Skip npm install'}
     ]
-  }, require('./init'));
+  }, initConsole);
 
-  console.register('version', 'Display version information.', {}, require('./version'));
+  console.register('version', 'Display version information.', {}, versionConsole);
 };

--- a/lib/console/index.ts
+++ b/lib/console/index.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 import helpConsole from './help';
 import initConsole from './init';
 import versionConsole from './version';

--- a/lib/console/init.ts
+++ b/lib/console/init.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-import BluebirdPromise from 'bluebird';
+import BlueBirdPromise from 'bluebird';
 import {join, resolve} from 'path';
 import {magenta} from 'picocolors';
 import {existsSync, readdirSync, rmdir, unlink, copyDir, readdir, stat} from 'hexo-fs';
@@ -20,7 +20,7 @@ async function initConsole(args) {
 
   if (existsSync(target) && readdirSync(target).length !== 0) {
     log.fatal(`${magenta(tildify(target))} not empty, please run \`hexo init\` on an empty folder and then copy your files into it`);
-    await BluebirdPromise.reject(new Error('target not empty'));
+    await BlueBirdPromise.reject(new Error('target not empty'));
   }
 
   log.info('Cloning hexo-starter', GIT_REPO_URL);
@@ -38,7 +38,7 @@ async function initConsole(args) {
     await copyAsset(target);
   }
 
-  await BluebirdPromise.all([
+  await BlueBirdPromise.all([
     removeGitDir(target),
     removeGitModules(target)
   ]);

--- a/lib/console/init.ts
+++ b/lib/console/init.ts
@@ -1,12 +1,12 @@
 'use strict';
 
-const Promise = require('bluebird');
-const { join, resolve } = require('path');
-const { magenta } = require('picocolors');
-const { existsSync, readdirSync, rmdir, unlink, copyDir, readdir, stat } = require('hexo-fs');
-const tildify = require('tildify');
-const { spawn } = require('hexo-util');
-const commandExistsSync = require('command-exists').sync;
+import BluebirdPromise from 'bluebird';
+import {join, resolve} from 'path';
+import {magenta} from 'picocolors';
+import {existsSync, readdirSync, rmdir, unlink, copyDir, readdir, stat} from 'hexo-fs';
+import tildify from 'tildify';
+import {spawn} from 'hexo-util';
+import {sync as commandExistsSync} from 'command-exists';
 
 const ASSET_DIR = join(__dirname, '../../assets');
 const GIT_REPO_URL = 'https://github.com/hexojs/hexo-starter.git';
@@ -20,7 +20,7 @@ async function initConsole(args) {
 
   if (existsSync(target) && readdirSync(target).length !== 0) {
     log.fatal(`${magenta(tildify(target))} not empty, please run \`hexo init\` on an empty folder and then copy your files into it`);
-    await Promise.reject(new Error('target not empty'));
+    await BluebirdPromise.reject(new Error('target not empty'));
   }
 
   log.info('Cloning hexo-starter', GIT_REPO_URL);
@@ -38,7 +38,7 @@ async function initConsole(args) {
     await copyAsset(target);
   }
 
-  await Promise.all([
+  await BluebirdPromise.all([
     removeGitDir(target),
     removeGitModules(target)
   ]);
@@ -111,4 +111,4 @@ async function removeGitModules(target) {
   }
 }
 
-module.exports = initConsole;
+export = initConsole;

--- a/lib/console/init.ts
+++ b/lib/console/init.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 import BlueBirdPromise from 'bluebird';
 import {join, resolve} from 'path';
 import {magenta} from 'picocolors';

--- a/lib/console/init.ts
+++ b/lib/console/init.ts
@@ -1,10 +1,10 @@
 import BlueBirdPromise from 'bluebird';
-import {join, resolve} from 'path';
-import {magenta} from 'picocolors';
-import {existsSync, readdirSync, rmdir, unlink, copyDir, readdir, stat} from 'hexo-fs';
+import { join, resolve } from 'path';
+import { magenta } from 'picocolors';
+import { existsSync, readdirSync, rmdir, unlink, copyDir, readdir, stat } from 'hexo-fs';
 import tildify from 'tildify';
-import {spawn} from 'hexo-util';
-import {sync as commandExistsSync} from 'command-exists';
+import { spawn } from 'hexo-util';
+import { sync as commandExistsSync } from 'command-exists';
 
 const ASSET_DIR = join(__dirname, '../../assets');
 const GIT_REPO_URL = 'https://github.com/hexojs/hexo-starter.git';

--- a/lib/console/version.ts
+++ b/lib/console/version.ts
@@ -1,9 +1,9 @@
 'use strict';
 
-const os = require('os');
-const pkg = require('../../package.json');
-const Promise = require('bluebird');
-const { spawn } = require('hexo-util');
+import os from 'os';
+import pkg from '../../package.json';
+import BluebirdPromise from 'bluebird';
+import {spawn} from 'hexo-util';
 
 async function versionConsole(args) {
   const { versions, platform } = process;
@@ -33,7 +33,7 @@ async function versionConsole(args) {
     console.log('%s: %s', key, versions[key]);
   }
 
-  await Promise.resolve();
+  await BluebirdPromise.resolve();
 }
 
-module.exports = versionConsole;
+export = versionConsole;

--- a/lib/console/version.ts
+++ b/lib/console/version.ts
@@ -1,7 +1,7 @@
 import os from 'os';
 const pkg = require('../../package.json');
 import BlueBirdPromise from 'bluebird';
-import {spawn} from 'hexo-util';
+import { spawn } from 'hexo-util';
 
 async function versionConsole() {
   const { versions, platform } = process;

--- a/lib/console/version.ts
+++ b/lib/console/version.ts
@@ -3,7 +3,7 @@ const pkg = require('../../package.json');
 import BlueBirdPromise from 'bluebird';
 import {spawn} from 'hexo-util';
 
-async function versionConsole(args) {
+async function versionConsole() {
   const { versions, platform } = process;
   const keys = Object.keys(versions);
 

--- a/lib/console/version.ts
+++ b/lib/console/version.ts
@@ -1,8 +1,8 @@
 'use strict';
 
 import os from 'os';
-import pkg from '../../package.json';
-import BluebirdPromise from 'bluebird';
+const pkg =require('../../package.json');
+import BlueBirdPromise from 'bluebird';
 import {spawn} from 'hexo-util';
 
 async function versionConsole(args) {
@@ -33,7 +33,7 @@ async function versionConsole(args) {
     console.log('%s: %s', key, versions[key]);
   }
 
-  await BluebirdPromise.resolve();
+  await BlueBirdPromise.resolve();
 }
 
 export = versionConsole;

--- a/lib/console/version.ts
+++ b/lib/console/version.ts
@@ -1,7 +1,5 @@
-'use strict';
-
 import os from 'os';
-const pkg =require('../../package.json');
+const pkg = require('../../package.json');
 import BlueBirdPromise from 'bluebird';
 import {spawn} from 'hexo-util';
 

--- a/lib/context.ts
+++ b/lib/context.ts
@@ -7,9 +7,11 @@ import ConsoleExtend from './extend/console';
 // a stub Hexo object
 // see `hexojs/hexo/lib/hexo/index.js`
 
+type Callback = (err?: any, value?: any) => void;
+
 class Context extends EventEmitter {
   base_dir: string;
-  log: any;
+  log: logger;
   extend: {
     console: ConsoleExtend;
   };
@@ -28,11 +30,11 @@ class Context extends EventEmitter {
     // Do nothing
   }
 
-  call(name: string, args: object, callback: Function);
-  call(name: string, args: Function);
-  call(name, args: object | Function, callback?: Function) {
+  call(name: string, args: object, callback: Callback);
+  call(name: string, callback?: Callback);
+  call(name: string, args?: object | Callback, callback?: Callback) {
     if (!callback && typeof args === 'function') {
-      callback = args;
+      callback = args as Callback;
       args = {};
     }
 

--- a/lib/context.ts
+++ b/lib/context.ts
@@ -1,6 +1,6 @@
 import logger from 'hexo-log';
-import {underline} from 'picocolors';
-import {EventEmitter} from 'events';
+import { underline } from 'picocolors';
+import { EventEmitter } from 'events';
 import Promise from 'bluebird';
 import ConsoleExtend from './extend/console';
 

--- a/lib/context.ts
+++ b/lib/context.ts
@@ -1,15 +1,21 @@
 'use strict';
 
-const logger = require('hexo-log');
-const { underline } = require('picocolors');
-const { EventEmitter } = require('events');
-const Promise = require('bluebird');
-const ConsoleExtend = require('./extend/console');
+import logger from 'hexo-log';
+import {underline} from 'picocolors';
+import {EventEmitter} from 'events';
+import Promise from 'bluebird';
+import ConsoleExtend from './extend/console';
 
 // a stub Hexo object
 // see `hexojs/hexo/lib/hexo/index.js`
 
 class Context extends EventEmitter {
+  base_dir: string;
+  log: any;
+  extend: {
+    console: ConsoleExtend;
+  }
+
   constructor(base = process.cwd(), args = {}) {
     super();
     this.base_dir = base;
@@ -24,7 +30,7 @@ class Context extends EventEmitter {
     // Do nothing
   }
 
-  call(name, args, callback) {
+  call(name: string, args: object | Function, callback?: Function) {
     if (!callback && typeof args === 'function') {
       callback = args;
       args = {};
@@ -41,7 +47,7 @@ class Context extends EventEmitter {
     }).asCallback(callback);
   }
 
-  exit(err) {
+  exit(err?: Error) {
     if (err) {
       this.log.fatal(
         {err},
@@ -58,4 +64,4 @@ class Context extends EventEmitter {
   }
 }
 
-module.exports = Context;
+export = Context;

--- a/lib/context.ts
+++ b/lib/context.ts
@@ -30,7 +30,9 @@ class Context extends EventEmitter {
     // Do nothing
   }
 
-  call(name: string, args: object | Function, callback?: Function) {
+  call(name: string, args: object, callback: Function);
+  call(name: string, args: Function);
+  call(name, args: object | Function, callback?: Function) {
     if (!callback && typeof args === 'function') {
       callback = args;
       args = {};

--- a/lib/context.ts
+++ b/lib/context.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 import logger from 'hexo-log';
 import {underline} from 'picocolors';
 import {EventEmitter} from 'events';
@@ -14,7 +12,7 @@ class Context extends EventEmitter {
   log: any;
   extend: {
     console: ConsoleExtend;
-  }
+  };
 
   constructor(base = process.cwd(), args = {}) {
     super();

--- a/lib/extend/console.ts
+++ b/lib/extend/console.ts
@@ -33,10 +33,10 @@ class Console {
     return this.store;
   }
 
-  register(name: string, desc: string, options: object, fn: Callback);
-  register(name: string, options: object, fn: Callback);
-  register(name: string, desc: string, fn: Callback);
-  register(name: string, fn: Callback);
+  register(name: string, desc: string, options: object, fn: Callback): void;
+  register(name: string, options: object, fn: Callback): void;
+  register(name: string, desc: string, fn: Callback): void;
+  register(name: string, fn: Callback): void;
   register(name: string, desc: string | object | Callback, options?: object | Callback, fn?: Callback) {
     if (!name) throw new TypeError('name is required');
 

--- a/lib/extend/console.ts
+++ b/lib/extend/console.ts
@@ -1,8 +1,14 @@
 import Promise from 'bluebird';
 import abbrev from 'abbrev';
 
+interface Callback {
+  (args?: object): any;
+  options?: object;
+  desc?: string;
+}
+
 interface Store {
-  [key: string]: Function;
+  [key: string]: Callback;
 }
 
 interface Alias {
@@ -27,13 +33,17 @@ class Console {
     return this.store;
   }
 
-  register(name, desc, options, fn) {
+  register(name: string, desc: string, options: object, fn: Callback);
+  register(name: string, options: object, fn: Callback);
+  register(name: string, desc: string, fn: Callback);
+  register(name: string, fn: Callback);
+  register(name: string, desc: string | object | Callback, options?: object | Callback, fn?: Callback) {
     if (!name) throw new TypeError('name is required');
 
     if (!fn) {
       if (options) {
         if (typeof options === 'function') {
-          fn = options;
+          fn = options as Callback;
 
           if (typeof desc === 'object') { // name, options, fn
             options = desc;
@@ -47,7 +57,7 @@ class Console {
       } else {
         // name, fn
         if (typeof desc === 'function') {
-          fn = desc;
+          fn = desc as Callback;
           options = {};
           desc = '';
         } else {
@@ -65,7 +75,7 @@ class Console {
     this.store[name.toLowerCase()] = fn;
     const c = fn;
     c.options = options;
-    c.desc = desc;
+    c.desc = desc as string;
 
     this.alias = abbrev(Object.keys(this.store));
   }

--- a/lib/extend/console.ts
+++ b/lib/extend/console.ts
@@ -1,15 +1,26 @@
 'use strict';
 
-const Promise = require('bluebird');
-const abbrev = require('abbrev');
+import Promise from 'bluebird';
+import abbrev from 'abbrev';
+
+interface Store {
+  [key: string]: Function;
+}
+
+interface Alias {
+  [key: string]: string;
+}
 
 class Console {
+  store: Store;
+  alias: Alias;
+
   constructor() {
     this.store = {};
     this.alias = {};
   }
 
-  get(name) {
+  get(name: string) {
     name = name.toLowerCase();
     return this.store[this.alias[name]];
   }
@@ -62,4 +73,4 @@ class Console {
   }
 }
 
-module.exports = Console;
+export = Console;

--- a/lib/extend/console.ts
+++ b/lib/extend/console.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 import Promise from 'bluebird';
 import abbrev from 'abbrev';
 

--- a/lib/find_pkg.ts
+++ b/lib/find_pkg.ts
@@ -1,5 +1,5 @@
-import {resolve, join, dirname} from 'path';
-import {readFile} from 'hexo-fs';
+import { resolve, join, dirname } from 'path';
+import { readFile } from 'hexo-fs';
 
 interface findPkgArgs {
   cwd?: string;

--- a/lib/find_pkg.ts
+++ b/lib/find_pkg.ts
@@ -5,7 +5,7 @@ interface findPkgArgs {
   cwd?: string;
 }
 
-function findPkg(cwd, args: findPkgArgs = {}) {
+function findPkg(cwd: string, args: findPkgArgs = {}) {
   if (args.cwd) {
     cwd = resolve(cwd, args.cwd);
   }
@@ -13,7 +13,7 @@ function findPkg(cwd, args: findPkgArgs = {}) {
   return checkPkg(cwd);
 }
 
-function checkPkg(path) {
+function checkPkg(path: string) {
   const pkgPath = join(path, 'package.json');
 
   return readFile(pkgPath).then(content => {

--- a/lib/find_pkg.ts
+++ b/lib/find_pkg.ts
@@ -17,7 +17,7 @@ function checkPkg(path) {
   const pkgPath = join(path, 'package.json');
 
   return readFile(pkgPath).then(content => {
-    const json = JSON.parse(content);
+    const json = JSON.parse(content as string);
     if (typeof json.hexo === 'object') return path;
   }).catch(err => {
     if (err && err.code === 'ENOENT') {

--- a/lib/find_pkg.ts
+++ b/lib/find_pkg.ts
@@ -1,9 +1,13 @@
 'use strict';
 
-const { resolve, join, dirname } = require('path');
-const { readFile } = require('hexo-fs');
+import {resolve, join, dirname} from 'path';
+import {readFile} from 'hexo-fs';
 
-function findPkg(cwd, args = {}) {
+interface findPkgArgs {
+  cwd?: string;
+}
+
+function findPkg(cwd, args: findPkgArgs = {}) {
   if (args.cwd) {
     cwd = resolve(cwd, args.cwd);
   }
@@ -29,4 +33,4 @@ function checkPkg(path) {
   });
 }
 
-module.exports = findPkg;
+export = findPkg;

--- a/lib/find_pkg.ts
+++ b/lib/find_pkg.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 import {resolve, join, dirname} from 'path';
 import {readFile} from 'hexo-fs';
 

--- a/lib/goodbye.ts
+++ b/lib/goodbye.ts
@@ -9,4 +9,4 @@ const byeWords = [
   'Catch you later'
 ];
 
-module.exports = () => byeWords[(Math.random() * byeWords.length) | 0];
+export = () => byeWords[(Math.random() * byeWords.length) | 0];

--- a/lib/goodbye.ts
+++ b/lib/goodbye.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 const byeWords = [
   'Good bye',
   'See you again',

--- a/lib/hexo.ts
+++ b/lib/hexo.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 import {magenta} from 'picocolors';
 import tildify from 'tildify';
 import Promise from 'bluebird';
@@ -9,7 +7,6 @@ import goodbye from './goodbye';
 import minimist from 'minimist';
 import resolve from 'resolve';
 import { camelCaseKeys } from 'hexo-util';
-
 import Console from './console';
 import helpConsole from './console/help';
 import initConsole from './console/init';

--- a/lib/hexo.ts
+++ b/lib/hexo.ts
@@ -1,4 +1,4 @@
-import {magenta} from 'picocolors';
+import { magenta } from 'picocolors';
 import tildify from 'tildify';
 import Promise from 'bluebird';
 import Context from './context';

--- a/lib/hexo.ts
+++ b/lib/hexo.ts
@@ -1,14 +1,19 @@
 'use strict';
 
-const { magenta } = require('picocolors');
-const tildify = require('tildify');
-const Promise = require('bluebird');
-const Context = require('./context');
-const findPkg = require('./find_pkg');
-const goodbye = require('./goodbye');
-const minimist = require('minimist');
-const resolve = require('resolve');
-const { camelCaseKeys } = require('hexo-util');
+import {magenta} from 'picocolors';
+import tildify from 'tildify';
+import Promise from 'bluebird';
+import Context from './context';
+import findPkg from './find_pkg';
+import goodbye from './goodbye';
+import minimist from 'minimist';
+import resolve from 'resolve';
+import { camelCaseKeys } from 'hexo-util';
+
+import Console from './console';
+import helpConsole from './console/help';
+import initConsole from './console/init';
+import versionConsole from './console/version';
 
 class HexoNotFoundError extends Error {}
 
@@ -44,7 +49,7 @@ function entry(cwd = process.cwd(), args) {
     if (mod) hexo = mod;
     log = hexo.log;
 
-    require('./console')(hexo);
+    Console(hexo);
 
     return hexo.init();
   }).then(() => {
@@ -65,9 +70,9 @@ function entry(cwd = process.cwd(), args) {
 }
 
 entry.console = {
-  init: require('./console/init'),
-  help: require('./console/help'),
-  version: require('./console/version')
+  init: initConsole,
+  help: helpConsole,
+  version: versionConsole
 };
 
 entry.version = require('../package.json').version;
@@ -93,4 +98,4 @@ function watchSignal(hexo) {
   });
 }
 
-module.exports = entry;
+export = entry;

--- a/lib/hexo.ts
+++ b/lib/hexo.ts
@@ -7,7 +7,7 @@ import goodbye from './goodbye';
 import minimist from 'minimist';
 import resolve from 'resolve';
 import { camelCaseKeys } from 'hexo-util';
-import Console from './console';
+import registerConsole from './console';
 import helpConsole from './console/help';
 import initConsole from './console/init';
 import versionConsole from './console/version';
@@ -46,7 +46,7 @@ function entry(cwd = process.cwd(), args) {
     if (mod) hexo = mod;
     log = hexo.log;
 
-    Console(hexo);
+    registerConsole(hexo);
 
     return hexo.init();
   }).then(() => {

--- a/lib/hexo.ts
+++ b/lib/hexo.ts
@@ -72,7 +72,7 @@ entry.console = {
   version: versionConsole
 };
 
-entry.version = require('../package.json').version;
+entry.version = require('../package.json').version as string;
 
 function loadModule(path, args) {
   return Promise.try(() => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,9 @@
         "hexo": "bin/hexo"
       },
       "devDependencies": {
+        "@types/node": "^18.11.8",
+        "@typescript-eslint/eslint-plugin": "^5.41.0",
+        "@typescript-eslint/parser": "^5.41.0",
         "chai": "^4.3.4",
         "eslint": "^8.2.0",
         "eslint-config-hexo": "^5.0.0",
@@ -32,7 +35,9 @@
         "nyc": "^15.1.0",
         "proxyquire": "^2.1.3",
         "rewire": "^6.0.0",
-        "sinon": "^14.0.0"
+        "sinon": "^14.0.0",
+        "ts-node": "^10.9.1",
+        "typescript": "^4.8.4"
       },
       "engines": {
         "node": ">=14"
@@ -318,6 +323,18 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@eslint/eslintrc": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.0.tgz",
@@ -459,6 +476,31 @@
         "node": ">=8"
       }
     },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
+      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.4.14",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+      "dev": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -538,23 +580,58 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
+      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
+      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
+      "dev": true
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.11",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
       "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
       "dev": true
     },
+    "node_modules/@types/node": {
+      "version": "18.11.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.8.tgz",
+      "integrity": "sha512-uGwPWlE0Hj972KkHtCDVwZ8O39GmyjfMane1Z3GUBGGnkZ2USDq7SxLpVIiIHpweY9DS0QTDH0Nw7RNBsAAZ5A==",
+      "dev": true
+    },
+    "node_modules/@types/semver": {
+      "version": "7.3.13",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
+      "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
+      "dev": true
+    },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "5.33.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.33.1.tgz",
-      "integrity": "sha512-S1iZIxrTvKkU3+m63YUOxYPKaP+yWDQrdhxTglVDVEVBf+aCSw85+BmJnyUaQQsk5TXFG/LpBu9fa+LrAQ91fQ==",
+      "version": "5.41.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.41.0.tgz",
+      "integrity": "sha512-DXUS22Y57/LAFSg3x7Vi6RNAuLpTXwxB9S2nIA7msBb/Zt8p7XqMwdpdc1IU7CkOQUPgAqR5fWvxuKCbneKGmA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.33.1",
-        "@typescript-eslint/type-utils": "5.33.1",
-        "@typescript-eslint/utils": "5.33.1",
+        "@typescript-eslint/scope-manager": "5.41.0",
+        "@typescript-eslint/type-utils": "5.41.0",
+        "@typescript-eslint/utils": "5.41.0",
         "debug": "^4.3.4",
-        "functional-red-black-tree": "^1.0.1",
         "ignore": "^5.2.0",
         "regexpp": "^3.2.0",
         "semver": "^7.3.7",
@@ -593,14 +670,14 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "5.33.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.33.1.tgz",
-      "integrity": "sha512-IgLLtW7FOzoDlmaMoXdxG8HOCByTBXrB1V2ZQYSEV1ggMmJfAkMWTwUjjzagS6OkfpySyhKFkBw7A9jYmcHpZA==",
+      "version": "5.41.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.41.0.tgz",
+      "integrity": "sha512-HQVfix4+RL5YRWZboMD1pUfFN8MpRH4laziWkkAzyO1fvNOY/uinZcvo3QiFJVS/siNHupV8E5+xSwQZrl6PZA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.33.1",
-        "@typescript-eslint/types": "5.33.1",
-        "@typescript-eslint/typescript-estree": "5.33.1",
+        "@typescript-eslint/scope-manager": "5.41.0",
+        "@typescript-eslint/types": "5.41.0",
+        "@typescript-eslint/typescript-estree": "5.41.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -620,13 +697,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.33.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.33.1.tgz",
-      "integrity": "sha512-8ibcZSqy4c5m69QpzJn8XQq9NnqAToC8OdH/W6IXPXv83vRyEDPYLdjAlUx8h/rbusq6MkW4YdQzURGOqsn3CA==",
+      "version": "5.41.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.41.0.tgz",
+      "integrity": "sha512-xOxPJCnuktUkY2xoEZBKXO5DBCugFzjrVndKdUnyQr3+9aDWZReKq9MhaoVnbL+maVwWJu/N0SEtrtEUNb62QQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.33.1",
-        "@typescript-eslint/visitor-keys": "5.33.1"
+        "@typescript-eslint/types": "5.41.0",
+        "@typescript-eslint/visitor-keys": "5.41.0"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -637,12 +714,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "5.33.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.33.1.tgz",
-      "integrity": "sha512-X3pGsJsD8OiqhNa5fim41YtlnyiWMF/eKsEZGsHID2HcDqeSC5yr/uLOeph8rNF2/utwuI0IQoAK3fpoxcLl2g==",
+      "version": "5.41.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.41.0.tgz",
+      "integrity": "sha512-L30HNvIG6A1Q0R58e4hu4h+fZqaO909UcnnPbwKiN6Rc3BUEx6ez2wgN7aC0cBfcAjZfwkzE+E2PQQ9nEuoqfA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/utils": "5.33.1",
+        "@typescript-eslint/typescript-estree": "5.41.0",
+        "@typescript-eslint/utils": "5.41.0",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       },
@@ -663,9 +741,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "5.33.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.33.1.tgz",
-      "integrity": "sha512-7K6MoQPQh6WVEkMrMW5QOA5FO+BOwzHSNd0j3+BlBwd6vtzfZceJ8xJ7Um2XDi/O3umS8/qDX6jdy2i7CijkwQ==",
+      "version": "5.41.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.41.0.tgz",
+      "integrity": "sha512-5BejraMXMC+2UjefDvrH0Fo/eLwZRV6859SXRg+FgbhA0R0l6lDqDGAQYhKbXhPN2ofk2kY5sgGyLNL907UXpA==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -676,13 +754,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.33.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.33.1.tgz",
-      "integrity": "sha512-JOAzJ4pJ+tHzA2pgsWQi4804XisPHOtbvwUyqsuuq8+y5B5GMZs7lI1xDWs6V2d7gE/Ez5bTGojSK12+IIPtXA==",
+      "version": "5.41.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.41.0.tgz",
+      "integrity": "sha512-SlzFYRwFSvswzDSQ/zPkIWcHv8O5y42YUskko9c4ki+fV6HATsTODUPbRbcGDFYP86gaJL5xohUEytvyNNcXWg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.33.1",
-        "@typescript-eslint/visitor-keys": "5.33.1",
+        "@typescript-eslint/types": "5.41.0",
+        "@typescript-eslint/visitor-keys": "5.41.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -703,9 +781,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -718,17 +796,19 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "5.33.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.33.1.tgz",
-      "integrity": "sha512-uphZjkMaZ4fE8CR4dU7BquOV6u0doeQAr8n6cQenl/poMaIyJtBu8eys5uk6u5HiDH01Mj5lzbJ5SfeDz7oqMQ==",
+      "version": "5.41.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.41.0.tgz",
+      "integrity": "sha512-QlvfwaN9jaMga9EBazQ+5DDx/4sAdqDkcs05AsQHMaopluVCUyu1bTRUVKzXbgjDlrRAQrYVoi/sXJ9fmG+KLQ==",
       "dev": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.33.1",
-        "@typescript-eslint/types": "5.33.1",
-        "@typescript-eslint/typescript-estree": "5.33.1",
+        "@types/semver": "^7.3.12",
+        "@typescript-eslint/scope-manager": "5.41.0",
+        "@typescript-eslint/types": "5.41.0",
+        "@typescript-eslint/typescript-estree": "5.41.0",
         "eslint-scope": "^5.1.1",
-        "eslint-utils": "^3.0.0"
+        "eslint-utils": "^3.0.0",
+        "semver": "^7.3.7"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -741,13 +821,28 @@
         "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
-    "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.33.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.33.1.tgz",
-      "integrity": "sha512-nwIxOK8Z2MPWltLKMLOEZwmfBZReqUdbEoHQXeCpa+sRVARe5twpJGHCB4dk9903Yaf0nMAlGbQfaAH92F60eg==",
+    "node_modules/@typescript-eslint/utils/node_modules/semver": {
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.33.1",
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "5.41.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.41.0.tgz",
+      "integrity": "sha512-vilqeHj267v8uzzakbm13HkPMl7cbYpKVjgFWZPIOHIJHZtinvypUhJ5xBXfWYg4eFKqztbMMpOgFpT9Gfx4fw==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.41.0",
         "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
@@ -926,6 +1021,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
       "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
+      "dev": true
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
       "dev": true
     },
     "node_modules/argparse": {
@@ -1228,6 +1329,12 @@
       "dependencies": {
         "safe-buffer": "~5.1.1"
       }
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -3165,6 +3272,12 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
+    },
     "node_modules/marked": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/marked/-/marked-4.1.1.tgz",
@@ -4637,6 +4750,58 @@
         "node": ">=12"
       }
     },
+    "node_modules/ts-node": {
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
+      "dev": true,
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-node/node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
@@ -4698,11 +4863,10 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
       "dev": true,
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4753,6 +4917,12 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz",
       "integrity": "sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==",
+      "dev": true
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true
     },
     "node_modules/w3c-xmlserializer": {
@@ -4983,6 +5153,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {
@@ -5253,6 +5432,15 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      }
+    },
     "@eslint/eslintrc": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.0.tgz",
@@ -5361,6 +5549,28 @@
       "integrity": "sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==",
       "dev": true
     },
+    "@jridgewell/resolve-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
+      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+      "dev": true
+    },
+    "@jridgewell/sourcemap-codec": {
+      "version": "1.4.14",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+      "dev": true
+    },
+    "@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -5428,23 +5638,58 @@
       "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
       "dev": true
     },
+    "@tsconfig/node10": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
+      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
+      "dev": true
+    },
+    "@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true
+    },
+    "@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true
+    },
+    "@tsconfig/node16": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
+      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
+      "dev": true
+    },
     "@types/json-schema": {
       "version": "7.0.11",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
       "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
       "dev": true
     },
+    "@types/node": {
+      "version": "18.11.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.8.tgz",
+      "integrity": "sha512-uGwPWlE0Hj972KkHtCDVwZ8O39GmyjfMane1Z3GUBGGnkZ2USDq7SxLpVIiIHpweY9DS0QTDH0Nw7RNBsAAZ5A==",
+      "dev": true
+    },
+    "@types/semver": {
+      "version": "7.3.13",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
+      "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
+      "dev": true
+    },
     "@typescript-eslint/eslint-plugin": {
-      "version": "5.33.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.33.1.tgz",
-      "integrity": "sha512-S1iZIxrTvKkU3+m63YUOxYPKaP+yWDQrdhxTglVDVEVBf+aCSw85+BmJnyUaQQsk5TXFG/LpBu9fa+LrAQ91fQ==",
+      "version": "5.41.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.41.0.tgz",
+      "integrity": "sha512-DXUS22Y57/LAFSg3x7Vi6RNAuLpTXwxB9S2nIA7msBb/Zt8p7XqMwdpdc1IU7CkOQUPgAqR5fWvxuKCbneKGmA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.33.1",
-        "@typescript-eslint/type-utils": "5.33.1",
-        "@typescript-eslint/utils": "5.33.1",
+        "@typescript-eslint/scope-manager": "5.41.0",
+        "@typescript-eslint/type-utils": "5.41.0",
+        "@typescript-eslint/utils": "5.41.0",
         "debug": "^4.3.4",
-        "functional-red-black-tree": "^1.0.1",
         "ignore": "^5.2.0",
         "regexpp": "^3.2.0",
         "semver": "^7.3.7",
@@ -5463,52 +5708,53 @@
       }
     },
     "@typescript-eslint/parser": {
-      "version": "5.33.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.33.1.tgz",
-      "integrity": "sha512-IgLLtW7FOzoDlmaMoXdxG8HOCByTBXrB1V2ZQYSEV1ggMmJfAkMWTwUjjzagS6OkfpySyhKFkBw7A9jYmcHpZA==",
+      "version": "5.41.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.41.0.tgz",
+      "integrity": "sha512-HQVfix4+RL5YRWZboMD1pUfFN8MpRH4laziWkkAzyO1fvNOY/uinZcvo3QiFJVS/siNHupV8E5+xSwQZrl6PZA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.33.1",
-        "@typescript-eslint/types": "5.33.1",
-        "@typescript-eslint/typescript-estree": "5.33.1",
+        "@typescript-eslint/scope-manager": "5.41.0",
+        "@typescript-eslint/types": "5.41.0",
+        "@typescript-eslint/typescript-estree": "5.41.0",
         "debug": "^4.3.4"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "5.33.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.33.1.tgz",
-      "integrity": "sha512-8ibcZSqy4c5m69QpzJn8XQq9NnqAToC8OdH/W6IXPXv83vRyEDPYLdjAlUx8h/rbusq6MkW4YdQzURGOqsn3CA==",
+      "version": "5.41.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.41.0.tgz",
+      "integrity": "sha512-xOxPJCnuktUkY2xoEZBKXO5DBCugFzjrVndKdUnyQr3+9aDWZReKq9MhaoVnbL+maVwWJu/N0SEtrtEUNb62QQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.33.1",
-        "@typescript-eslint/visitor-keys": "5.33.1"
+        "@typescript-eslint/types": "5.41.0",
+        "@typescript-eslint/visitor-keys": "5.41.0"
       }
     },
     "@typescript-eslint/type-utils": {
-      "version": "5.33.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.33.1.tgz",
-      "integrity": "sha512-X3pGsJsD8OiqhNa5fim41YtlnyiWMF/eKsEZGsHID2HcDqeSC5yr/uLOeph8rNF2/utwuI0IQoAK3fpoxcLl2g==",
+      "version": "5.41.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.41.0.tgz",
+      "integrity": "sha512-L30HNvIG6A1Q0R58e4hu4h+fZqaO909UcnnPbwKiN6Rc3BUEx6ez2wgN7aC0cBfcAjZfwkzE+E2PQQ9nEuoqfA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/utils": "5.33.1",
+        "@typescript-eslint/typescript-estree": "5.41.0",
+        "@typescript-eslint/utils": "5.41.0",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "5.33.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.33.1.tgz",
-      "integrity": "sha512-7K6MoQPQh6WVEkMrMW5QOA5FO+BOwzHSNd0j3+BlBwd6vtzfZceJ8xJ7Um2XDi/O3umS8/qDX6jdy2i7CijkwQ==",
+      "version": "5.41.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.41.0.tgz",
+      "integrity": "sha512-5BejraMXMC+2UjefDvrH0Fo/eLwZRV6859SXRg+FgbhA0R0l6lDqDGAQYhKbXhPN2ofk2kY5sgGyLNL907UXpA==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "5.33.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.33.1.tgz",
-      "integrity": "sha512-JOAzJ4pJ+tHzA2pgsWQi4804XisPHOtbvwUyqsuuq8+y5B5GMZs7lI1xDWs6V2d7gE/Ez5bTGojSK12+IIPtXA==",
+      "version": "5.41.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.41.0.tgz",
+      "integrity": "sha512-SlzFYRwFSvswzDSQ/zPkIWcHv8O5y42YUskko9c4ki+fV6HATsTODUPbRbcGDFYP86gaJL5xohUEytvyNNcXWg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.33.1",
-        "@typescript-eslint/visitor-keys": "5.33.1",
+        "@typescript-eslint/types": "5.41.0",
+        "@typescript-eslint/visitor-keys": "5.41.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -5517,9 +5763,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "7.3.7",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+          "version": "7.3.8",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -5528,26 +5774,39 @@
       }
     },
     "@typescript-eslint/utils": {
-      "version": "5.33.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.33.1.tgz",
-      "integrity": "sha512-uphZjkMaZ4fE8CR4dU7BquOV6u0doeQAr8n6cQenl/poMaIyJtBu8eys5uk6u5HiDH01Mj5lzbJ5SfeDz7oqMQ==",
+      "version": "5.41.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.41.0.tgz",
+      "integrity": "sha512-QlvfwaN9jaMga9EBazQ+5DDx/4sAdqDkcs05AsQHMaopluVCUyu1bTRUVKzXbgjDlrRAQrYVoi/sXJ9fmG+KLQ==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.33.1",
-        "@typescript-eslint/types": "5.33.1",
-        "@typescript-eslint/typescript-estree": "5.33.1",
+        "@types/semver": "^7.3.12",
+        "@typescript-eslint/scope-manager": "5.41.0",
+        "@typescript-eslint/types": "5.41.0",
+        "@typescript-eslint/typescript-estree": "5.41.0",
         "eslint-scope": "^5.1.1",
-        "eslint-utils": "^3.0.0"
+        "eslint-utils": "^3.0.0",
+        "semver": "^7.3.7"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.3.8",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "5.33.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.33.1.tgz",
-      "integrity": "sha512-nwIxOK8Z2MPWltLKMLOEZwmfBZReqUdbEoHQXeCpa+sRVARe5twpJGHCB4dk9903Yaf0nMAlGbQfaAH92F60eg==",
+      "version": "5.41.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.41.0.tgz",
+      "integrity": "sha512-vilqeHj267v8uzzakbm13HkPMl7cbYpKVjgFWZPIOHIJHZtinvypUhJ5xBXfWYg4eFKqztbMMpOgFpT9Gfx4fw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.33.1",
+        "@typescript-eslint/types": "5.41.0",
         "eslint-visitor-keys": "^3.3.0"
       },
       "dependencies": {
@@ -5679,6 +5938,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
       "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
+      "dev": true
+    },
+    "arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
       "dev": true
     },
     "argparse": {
@@ -5923,6 +6188,12 @@
       "requires": {
         "safe-buffer": "~5.1.1"
       }
+    },
+    "create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
     },
     "cross-spawn": {
       "version": "7.0.3",
@@ -7369,6 +7640,12 @@
         }
       }
     },
+    "make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
+    },
     "marked": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/marked/-/marked-4.1.1.tgz",
@@ -8477,6 +8754,35 @@
         "punycode": "^2.1.1"
       }
     },
+    "ts-node": {
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
+      "dev": true,
+      "requires": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+          "dev": true
+        }
+      }
+    },
     "tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
@@ -8523,11 +8829,10 @@
       }
     },
     "typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
-      "dev": true,
-      "peer": true
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
+      "dev": true
     },
     "universalify": {
       "version": "0.2.0",
@@ -8564,6 +8869,12 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz",
       "integrity": "sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==",
+      "dev": true
+    },
+    "v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true
     },
     "w3c-xmlserializer": {
@@ -8738,6 +9049,12 @@
           "dev": true
         }
       }
+    },
+    "yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true
     },
     "yocto-queue": {
       "version": "0.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "hexo": "bin/hexo"
       },
       "devDependencies": {
+        "@types/bluebird": "^3.5.37",
         "@types/node": "^18.11.8",
         "@typescript-eslint/eslint-plugin": "^5.41.0",
         "@typescript-eslint/parser": "^5.41.0",
@@ -604,6 +605,12 @@
       "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
       "dev": true
     },
+    "node_modules/@types/bluebird": {
+      "version": "3.5.37",
+      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.37.tgz",
+      "integrity": "sha512-g2qEd+zkfkTEudA2SrMAeAvY7CrFqtbsLILm2dT2VIeKTqMqVzcdfURlvu6FU3srRgbmXN1Srm94pg34EIehww==",
+      "dev": true
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.11",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
@@ -667,6 +674,21 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/tsutils": {
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
+      "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^1.8.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      },
+      "peerDependencies": {
+        "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
       }
     },
     "node_modules/@typescript-eslint/parser": {
@@ -740,6 +762,21 @@
         }
       }
     },
+    "node_modules/@typescript-eslint/type-utils/node_modules/tsutils": {
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
+      "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^1.8.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      },
+      "peerDependencies": {
+        "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
+      }
+    },
     "node_modules/@typescript-eslint/types": {
       "version": "5.41.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.41.0.tgz",
@@ -793,6 +830,21 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/tsutils": {
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
+      "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^1.8.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      },
+      "peerDependencies": {
+        "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
       }
     },
     "node_modules/@typescript-eslint/utils": {
@@ -4808,21 +4860,6 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "dev": true
     },
-    "node_modules/tsutils": {
-      "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
-      "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^1.8.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      },
-      "peerDependencies": {
-        "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
-      }
-    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -5662,6 +5699,12 @@
       "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
       "dev": true
     },
+    "@types/bluebird": {
+      "version": "3.5.37",
+      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.37.tgz",
+      "integrity": "sha512-g2qEd+zkfkTEudA2SrMAeAvY7CrFqtbsLILm2dT2VIeKTqMqVzcdfURlvu6FU3srRgbmXN1Srm94pg34EIehww==",
+      "dev": true
+    },
     "@types/json-schema": {
       "version": "7.0.11",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
@@ -5704,6 +5747,15 @@
           "requires": {
             "lru-cache": "^6.0.0"
           }
+        },
+        "tsutils": {
+          "version": "3.21.0",
+          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
+          "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.8.1"
+          }
         }
       }
     },
@@ -5739,6 +5791,17 @@
         "@typescript-eslint/utils": "5.41.0",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
+      },
+      "dependencies": {
+        "tsutils": {
+          "version": "3.21.0",
+          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
+          "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.8.1"
+          }
+        }
       }
     },
     "@typescript-eslint/types": {
@@ -5769,6 +5832,15 @@
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
+          }
+        },
+        "tsutils": {
+          "version": "3.21.0",
+          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
+          "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.8.1"
           }
         }
       }
@@ -8788,15 +8860,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "dev": true
-    },
-    "tsutils": {
-      "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
-      "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
-      "dev": true,
-      "requires": {
-        "tslib": "^1.8.1"
-      }
     },
     "type-check": {
       "version": "0.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "abbrev": "^1.1.1",
         "bluebird": "^3.7.2",
         "command-exists": "^1.2.9",
-        "hexo-fs": "^4.0.0",
+        "hexo-fs": "^4.1.1",
         "hexo-log": "^3.0.0",
         "hexo-util": "^2.5.0",
         "minimist": "^1.2.5",
@@ -2627,9 +2627,9 @@
       }
     },
     "node_modules/hexo-fs": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/hexo-fs/-/hexo-fs-4.0.0.tgz",
-      "integrity": "sha512-nyFouUzoxabGraHzDGoF90sq+KDlZV94nUQarfVxwxBdI7x3LVeb9Y3r+HKYyxUyo2HtrJUILJh3UM0qzdBq9A==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/hexo-fs/-/hexo-fs-4.1.1.tgz",
+      "integrity": "sha512-aDysNTyv8ElcerbFVbPLRXnYt+QDY6gAOZZ5DLbCxudY0Ywppqd+uZ03gZ2BDypIBvmNB27WYWYz76M+Yv/YXw==",
       "dependencies": {
         "bluebird": "^3.7.2",
         "chokidar": "^3.5.3",
@@ -7170,9 +7170,9 @@
       "dev": true
     },
     "hexo-fs": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/hexo-fs/-/hexo-fs-4.0.0.tgz",
-      "integrity": "sha512-nyFouUzoxabGraHzDGoF90sq+KDlZV94nUQarfVxwxBdI7x3LVeb9Y3r+HKYyxUyo2HtrJUILJh3UM0qzdBq9A==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/hexo-fs/-/hexo-fs-4.1.1.tgz",
+      "integrity": "sha512-aDysNTyv8ElcerbFVbPLRXnYt+QDY6gAOZZ5DLbCxudY0Ywppqd+uZ03gZ2BDypIBvmNB27WYWYz76M+Yv/YXw==",
       "requires": {
         "bluebird": "^3.7.2",
         "chokidar": "^3.5.3",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "tildify": "^2.0.0"
   },
   "devDependencies": {
+    "@types/bluebird": "^3.5.37",
     "@types/node": "^18.11.8",
     "@typescript-eslint/eslint-plugin": "^5.41.0",
     "@typescript-eslint/parser": "^5.41.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "bin",
     "assets"
   ],
-  "types": "./dist/**/*.d.ts",
+  "types": "./dist/hexo.d.ts",
   "scripts": {
     "prepublish ": "npm run clean && npm run build",
     "build": "tsc -b",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "abbrev": "^1.1.1",
     "bluebird": "^3.7.2",
     "command-exists": "^1.2.9",
-    "hexo-fs": "^4.0.0",
+    "hexo-fs": "^4.1.1",
     "hexo-log": "^3.0.0",
     "hexo-util": "^2.5.0",
     "minimist": "^1.2.5",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   ],
   "types": "./dist/hexo.d.ts",
   "scripts": {
-    "prepublish ": "npm run clean && npm run build",
+    "prepublish ": "npm install && npm run clean && npm run build",
     "build": "tsc -b",
     "clean": "tsc -b --clean",
     "eslint": "eslint .",

--- a/package.json
+++ b/package.json
@@ -7,14 +7,19 @@
     "hexo": "./bin/hexo"
   },
   "files": [
-    "lib",
+    "dist/**",
     "completion",
     "bin",
     "assets"
   ],
+  "types": "./dist/**/*.d.ts",
   "scripts": {
+    "prepublish ": "npm run clean && npm run build",
+    "build": "tsc -b",
+    "clean": "tsc -b --clean",
     "eslint": "eslint .",
-    "test": "mocha test/index.js",
+    "pretest": "npm run clean && npm run build",
+    "test": "mocha test/index.js --require ts-node/register",
     "test-cov": "nyc --reporter=lcovonly npm test",
     "prepare": "git submodule init && git submodule update && git submodule foreach git pull origin master"
   },
@@ -50,6 +55,9 @@
     "tildify": "^2.0.0"
   },
   "devDependencies": {
+    "@types/node": "^18.11.8",
+    "@typescript-eslint/eslint-plugin": "^5.41.0",
+    "@typescript-eslint/parser": "^5.41.0",
     "chai": "^4.3.4",
     "eslint": "^8.2.0",
     "eslint-config-hexo": "^5.0.0",
@@ -58,7 +66,9 @@
     "nyc": "^15.1.0",
     "proxyquire": "^2.1.3",
     "rewire": "^6.0.0",
-    "sinon": "^14.0.0"
+    "sinon": "^14.0.0",
+    "ts-node": "^10.9.1",
+    "typescript": "^4.8.4"
   },
   "engines": {
     "node": ">=14"

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -1,3 +1,6 @@
 {
-  "extends": "hexo/test"
+  "extends": "hexo/test",
+  "rules": {
+    "@typescript-eslint/no-var-requires": 0
+  }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const chai = require('chai');
+require('chai');
 
 describe('hexo-cli', () => {
   require('./scripts/find_pkg');

--- a/test/scripts/context.js
+++ b/test/scripts/context.js
@@ -5,7 +5,7 @@ const should = require('chai').should();
 const sinon = require('sinon');
 
 describe('context', () => {
-  const Context = require('../../lib/context');
+  const Context = require('../../dist/context');
 
   describe('call', () => {
     const hexo = new Context();

--- a/test/scripts/find_pkg.js
+++ b/test/scripts/find_pkg.js
@@ -5,7 +5,7 @@ const { rmdir, writeFile, unlink } = require('hexo-fs');
 const { dirname, join } = require('path');
 
 describe('Find package', () => {
-  const findPkg = require('../../lib/find_pkg');
+  const findPkg = require('../../dist/find_pkg');
   const baseDir = join(__dirname, 'find_pkg_test');
 
   after(async () => await rmdir(baseDir));

--- a/test/scripts/help.js
+++ b/test/scripts/help.js
@@ -1,7 +1,7 @@
 'use strict';
 
 require('chai').should();
-const Context = require('../../lib/context');
+const Context = require('../../dist/context');
 const sinon = require('sinon');
 const { readFile } = require('hexo-fs');
 const { join } = require('path');
@@ -13,10 +13,10 @@ function getConsoleLog({ args }) {
 }
 
 describe('help', () => {
-  const helpModule = rewire('../../lib/console/help');
+  const helpModule = rewire('../../dist/console/help');
   const hexo = new Context();
 
-  require('../../lib/console')(hexo);
+  require('../../dist/console')(hexo);
 
   it('show global help', () => {
     const spy = sinon.spy();

--- a/test/scripts/hexo.js
+++ b/test/scripts/hexo.js
@@ -9,7 +9,7 @@ describe('hexo', () => {
 
   it('run help if no specified command', async () => {
     const spy = sinon.spy();
-    const hexo = proxyquire('../../lib/hexo', {
+    const hexo = proxyquire('../../dist/hexo', {
       './console'(ctx) {
         ctx.extend.console.register('help', spy);
       }
@@ -21,7 +21,7 @@ describe('hexo', () => {
 
   it('run specified command', async () => {
     const spy = sinon.spy();
-    const hexo = proxyquire('../../lib/hexo', {
+    const hexo = proxyquire('../../dist/hexo', {
       './console'(ctx) {
         ctx.extend.console.register('test', spy);
       }
@@ -33,7 +33,7 @@ describe('hexo', () => {
 
   it('run help if specified command not found', async () => {
     const spy = sinon.spy();
-    const hexo = proxyquire('../../lib/hexo', {
+    const hexo = proxyquire('../../dist/hexo', {
       './console'(ctx) {
         ctx.extend.console.register('help', spy);
       }

--- a/test/scripts/init.js
+++ b/test/scripts/init.js
@@ -57,7 +57,7 @@ describe('init', () => {
   }
 
   function withoutSpawn(fn) {
-    return initModule.__with__('spawn', () => Promise.reject(new Error('spawn is not available')))(fn);
+    return initModule.__with__('hexo_util_1.spawn', () => Promise.reject(new Error('spawn is not available')))(fn);
   }
 
   before(async () => {

--- a/test/scripts/init.js
+++ b/test/scripts/init.js
@@ -5,12 +5,12 @@ const { join } = require('path');
 const { listDir, rmdir, createReadStream } = require('hexo-fs');
 const { createSha1Hash } = require('hexo-util');
 const rewire = require('rewire');
-const Context = require('../../lib/context');
+const Context = require('../../dist/context');
 const assetDir = join(__dirname, '../../assets');
 
 describe('init', () => {
   const baseDir = join(__dirname, 'init_test');
-  const initModule = rewire('../../lib/console/init');
+  const initModule = rewire('../../dist/console/init');
   const hexo = new Context(baseDir, { silent: true });
   const init = initModule.bind(hexo);
   let assets = [];

--- a/test/scripts/version.js
+++ b/test/scripts/version.js
@@ -1,7 +1,7 @@
 'use strict';
 
 require('chai').should();
-const Context = require('../../lib/context');
+const Context = require('../../dist/context');
 const sinon = require('sinon');
 const { platform, release } = require('os');
 const { format } = require('util');
@@ -14,7 +14,7 @@ function getConsoleLog({ args }) {
 }
 
 describe('version', () => {
-  const versionModule = rewire('../../lib/console/version');
+  const versionModule = rewire('../../dist/console/version');
   const hexo = new Context();
 
   it('show version info', () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es6",
+    "sourceMap": true,
+    "outDir": "dist",
+    "declaration": true,
+    "esModuleInterop": true,
+    "types": [
+      "node"
+    ]
+  },
+  "include": [
+    "lib/hexo.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}


### PR DESCRIPTION
There are some types missing in `hexo-fs` and `graceful-fs`. I'll work on the upstream first.

See https://github.com/hexojs/hexo-fs/pull/109

`"types"` in `package.json` may be incorrect