### PR TITLE
chore: ignroe `dependabot` for `npm`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,5 @@
 version: 2
 updates:
-- package-ecosystem: npm
-  directory: "/"
-  schedule:
-    interval: daily
 - package-ecosystem: github-actions
   directory: "/"
   schedule:


### PR DESCRIPTION
The current dependabot settings only updates the `package-lock.json` and does not update the `package.json`. The dependabot submits PR frequently which creates a lot of noise and conflicts. It's honestly 
very stressful for me. 

This PR for stop the updates by dependabot.

> see: https://github.com/orgs/hexojs/discussions/5167