### PR TITLE
chore: update deprecated `prepublish` and `repository` in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,10 @@
     "test-cov": "nyc --reporter=lcovonly npm test",
     "prepare": "git submodule init && git submodule update && git submodule foreach git pull origin master"
   },
-  "repository": "hexojs/hexo-cli",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/hexojs/hexo-cli.git"
+  },
   "homepage": "https://hexo.io/",
   "keywords": [
     "website",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   ],
   "types": "./dist/hexo.d.ts",
   "scripts": {
-    "prepublish ": "npm install && npm run clean && npm run build",
+    "prepublishOnly": "npm install && npm run clean && npm run build",
     "build": "tsc -b",
     "clean": "tsc -b --clean",
     "eslint": "eslint .",


### PR DESCRIPTION
## check list

- [ ] Add test cases for the changes.
- [ ] Passed the CI test.

## Changes

- `prepublish` has been deprecated https://docs.npmjs.com/cli/v10/using-npm/scripts#prepare-and-prepublish
- repository key from string to object
