### PR TITLE
feat: add support for package.yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "@types/bluebird": "^3.5.37",
     "@types/chai": "^4.3.14",
     "@types/command-exists": "^1.2.3",
+    "@types/js-yaml": "^4.0.9",
     "@types/minimist": "^1.2.5",
     "@types/mocha": "^10.0.6",
     "@types/node": "^18.11.8",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,9 @@
     "resolve": "^1.20.0",
     "tildify": "^2.0.0"
   },
+  "peerDependencies": {
+    "js-yaml": "^4.1.0"
+  },
   "devDependencies": {
     "@types/abbrev": "^1.1.5",
     "@types/bluebird": "^3.5.37",

--- a/package.json
+++ b/package.json
@@ -48,13 +48,11 @@
     "hexo-fs": "^4.1.1",
     "hexo-log": "^4.0.1",
     "hexo-util": "^3.3.0",
+    "js-yaml": "^4.1.0",
     "minimist": "^1.2.5",
     "picocolors": "^1.0.0",
     "resolve": "^1.20.0",
     "tildify": "^2.0.0"
-  },
-  "peerDependencies": {
-    "js-yaml": "^4.1.0"
   },
   "devDependencies": {
     "@types/abbrev": "^1.1.5",


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo!
-->

## check list

- [x] Add test cases for the changes.
- [ ] Passed the CI test.

## Description

Support `package.yaml` when checking package file with `hexo` in it.

## Additional information

Originally proposed in https://github.com/hexojs/hexo/issues/5534. Also solves #511.

Could be useful for pnpm users who prefers package.yaml.

resolves https://github.com/hexojs/hexo/issues/5534
resolves #511